### PR TITLE
Fix erroneous documentation

### DIFF
--- a/bindings/python/doc/extend.rst
+++ b/bindings/python/doc/extend.rst
@@ -50,7 +50,7 @@ tuple, strings, etc.)::
 
         @staticmethod
         def deserialize(inputs, name, state):
-            return = MySigmoid(inputs[0], name)
+            return MySigmoid(inputs[0], name)
 
 This can now be used as a normal operator like::
 


### PR DESCRIPTION
Removed the `=` sign in the documentation extend